### PR TITLE
fix: Remote wins does not send data back to server

### DIFF
--- a/record/record-conflicts.feature
+++ b/record/record-conflicts.feature
@@ -9,7 +9,12 @@ Feature: Record Conflicts
 	If a conflict does occur, the client should
 	recieve a VERSION_EXISTS error.
 
-	Background: 
+	These tests do not send anything back to the
+	server because by default record conflicts
+	are REMOTE_WINS, meaning they accepts the
+	server data
+
+	Background:
 	  Given the test server is ready
 	  And the client is initialised
 	  And the server sends the message C|A+
@@ -18,16 +23,16 @@ Feature: Record Conflicts
 	  And the client creates a record named "mergeRecord"
 	  When the server sends the message R|A|S|mergeRecord+
 	  And the server sends the message R|R|mergeRecord|100|{"key":"value1"}+
-	
+
 	Scenario: Record conflict on set
 
 	  # The client tries to set an out of date value
 	  Given the client sets the record "mergeRecord" "key" to "value3"
 	  When the server sends the message R|E|VERSION_EXISTS|mergeRecord|101|{"key":"value2"}+
-	  Then the last message the server recieved is R|U|mergeRecord|102|{"key":"value2"}+
+	  Then the last message the server recieved is R|P|mergeRecord|101|key|Svalue3+
 
 	Scenario: Record conflict from update
 
 	  # The client recieves an out of sync update
 	  When the server sends the message R|U|mergeRecord|100|{"key":"value3"}+
-	  Then the last message the server recieved is R|U|mergeRecord|101|{"key":"value3"}+
+	  Then the last message the server recieved is R|CR|mergeRecord+

--- a/record/record-writeAcknowledgement.feature
+++ b/record/record-writeAcknowledgement.feature
@@ -32,7 +32,7 @@ Scenario: Record write acknowledgement
 
 	Then the server sends the message R|WA|happyRecord|[101]|L+
 	Then the client is notified that the record "happyRecord" was written without error
-	
+
 	# The client sends update and gets acknowledgement
 	When the client sets the record "happyRecord" to {"newData":"someValue"}
 	Then the last message the server recieved is R|U|happyRecord|102|{"newData":"someValue"}|{"writeSuccess":true}+
@@ -57,6 +57,6 @@ Scenario: Record write acknowledgement
 	When the client sets the record "happyRecord" "validData" to "someData"
 	Then the last message the server recieved is R|P|happyRecord|105|validData|SsomeData|{"writeSuccess":true}+
 	Then the server sends the message R|E|VERSION_EXISTS|happyRecord|105|{"validData":"newErrorData"}|{"writeSuccess":true}+
-	Then the last message the server recieved is R|U|happyRecord|106|{"validData":"newErrorData"}|{"writeSuccess":true}+
+	Then the last message the server recieved is R|P|happyRecord|105|validData|SsomeData|{"writeSuccess":true}+
 	Then the server sends the message R|WA|happyRecord|[106]|L+
 	Then the client is notified that the record "happyRecord" was written without error


### PR DESCRIPTION
When remote wins is configure, clients should discard its current
state in favour of the servers