### PR TITLE
Added steps in timeout test spec to allow certain clients to be tested

### DIFF
--- a/events/events-listen-timeouts.feature
+++ b/events/events-listen-timeouts.feature
@@ -24,6 +24,9 @@ Feature: Event Listen Timeouts
 		Then the client throws a "ACK_TIMEOUT" error with message "No ACK message received in time for eventPrefix/.*"
 
 	# The client unlistens to eventPrefix
+		When the client listens to events matching "eventPrefix/.*"
+		Then the last message the server recieved is E|L|eventPrefix/.*+
+		Given the server sends the message E|A|L|eventPrefix/.*+
 		When the client unlistens to events matching "eventPrefix/.*"
 		Then the last message the server recieved is E|UL|eventPrefix/.*+
 

--- a/events/events-timeouts.feature
+++ b/events/events-timeouts.feature
@@ -22,6 +22,10 @@ Scenario: Events Timeouts
 	Then the client throws a "ACK_TIMEOUT" error with message "No ACK message received in time for test1"
 
 	# The client unsubscribes from an event
+	Given the client subscribes to an event named "test1"
+	Then the server received the message E|S|test1+
+	Given the server sends the message E|A|S|test1+
+
 	When the client unsubscribes from an event named "test1"
 	Then the server received the message E|US|test1+
 

--- a/events/events-timeouts.feature
+++ b/events/events-timeouts.feature
@@ -22,7 +22,7 @@ Scenario: Events Timeouts
 	Then the client throws a "ACK_TIMEOUT" error with message "No ACK message received in time for test1"
 
 	# The client unsubscribes from an event
-	Given the client subscribes to an event named "test1"
+	When the client subscribes to an event named "test1"
 	Then the server received the message E|S|test1+
 	Given the server sends the message E|A|S|test1+
 
@@ -30,5 +30,5 @@ Scenario: Events Timeouts
 	Then the server received the message E|US|test1+
 
 	# The server does not respond in time with an unsubscribe ACK
-	Given some time passes
+	When some time passes
 	Then the client throws a "ACK_TIMEOUT" error with message "No ACK message received in time for test1"


### PR DESCRIPTION
As I am implementing a deepstream client I ran into an issue where the unsubscribe timeout and unlisten timeout tests were not passing because the client, not being subscribed to the test event or listener, did not feel the need to send an unsubcribe/unlisten event to the server.

Judging by events-misc.feature this behaviour is in line with other parts of the spec as if the client subscribs mutiple times to an event only 1 messge is sent; likewise if the client is told to unsubscribe from an event it does not have an event map for should it really send an unsubscription event?

Thoughts?